### PR TITLE
User in Organization(s) Endpoint

### DIFF
--- a/lib/adaptable_costs_evaluator_web/controllers/user_controller.ex
+++ b/lib/adaptable_costs_evaluator_web/controllers/user_controller.ex
@@ -60,4 +60,16 @@ defmodule AdaptableCostsEvaluatorWeb.UserController do
         {:error, :unauthorized}
     end
   end
+
+  def organizations(conn, %{"id" => id}) do
+    user = Users.get_user!(id)
+
+    with :ok <- Bodyguard.permit(User, :organizations, current_user(conn), user.id) do
+      organizations = Users.list_organizations(user.id)
+
+      conn
+      |> put_view(AdaptableCostsEvaluatorWeb.OrganizationView)
+      |> render("index.json", organizations: organizations)
+    end
+  end
 end

--- a/lib/adaptable_costs_evaluator_web/router.ex
+++ b/lib/adaptable_costs_evaluator_web/router.ex
@@ -23,6 +23,7 @@ defmodule AdaptableCostsEvaluatorWeb.Router do
 
     # Users
     resources "/users", UserController, except: [:create, :new, :edit]
+    get "/users/:id/organizations", UserController, :organizations
 
     # Organizations
     resources "/organizations", OrganizationController, except: [:new, :edit]

--- a/test/adaptable_costs_evaluator_web/controllers/user_controller_test.exs
+++ b/test/adaptable_costs_evaluator_web/controllers/user_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule AdaptableCostsEvaluatorWeb.UserControllerTest do
   use AdaptableCostsEvaluatorWeb.ConnCase
-  use AdaptableCostsEvaluator.Fixtures.UserFixture
+  use AdaptableCostsEvaluator.Fixtures.{UserFixture, OrganizationFixture}
 
-  alias AdaptableCostsEvaluator.{Users, Guardian}
+  alias AdaptableCostsEvaluator.{Users, Guardian, Organizations}
 
   import AdaptableCostsEvaluator.Helpers.ConnHelper, only: [setup_conns: 2]
 
@@ -99,6 +99,16 @@ defmodule AdaptableCostsEvaluatorWeb.UserControllerTest do
       conn = post(conns[:plain], Routes.user_path(conns[:plain], :sign_in), body)
 
       assert json_response(conn, 401)["errors"] == ["unauthorized"]
+    end
+  end
+
+  describe "organizations" do
+    test "lists organizations of the user", %{conns: conns, user: user} do
+      organization = organization_fixture()
+      Organizations.create_membership(organization.id, user.id)
+
+      conn = get(conns[:authd], Routes.user_path(conns[:authd], :organizations, user.id))
+      assert json_response(conn, 200)["data"] == [organization_response(organization)]
     end
   end
 end


### PR DESCRIPTION
Implements `GET /users/:id/organizations` endpoint for getting the list of organizations the user is member of.

Closes #11. 